### PR TITLE
Link against conda-forge's libuuid

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
     - vs2015_int_fix.patch  # [win and py >= 35]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or osx]
   features:
     - vc9  # [win and py27]
@@ -52,6 +52,8 @@ requirements:
     - jom  # [win]
     # This is here because conda is not pulling libxml2 from conda-forge
     - libxml2 >=2.9.3
+    # This is here because some conda-forge libraries link against conda-forge's libuuid
+    - libuuid
   run:
     - freetype 2.6.*  # [unix]
     - fontconfig 2.11.*  # [linux]
@@ -63,6 +65,8 @@ requirements:
     - zlib 1.2.*
     # This is here because conda is not pulling libxml2 from conda-forge
     - libxml2 >=2.9.3
+    # This is here because some conda-forge libraries link against conda-forge's libuuid
+    - libuuid
 
 test:
   files:


### PR DESCRIPTION
Goal is to fix linking issues with Qt apps when libraries are installed that use conda-forge's libuuid (e.g., gdal) are also installed.

See issue:
https://github.com/conda-forge/libuuid-feedstock/issues/8