### PR TITLE
No conda-build 2 for now

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,10 +41,6 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# install conda-build 2.x to build a long prefix
-conda install --yes --quiet conda-build=2
-conda info
-
 # Install the yum requirements defined canonically in the
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line be updated
@@ -55,7 +51,4 @@ yum install -y libX11-devel libXt-devel libXext-devel chrpath libXrender-devel g
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-# inspect the prefix lengths of the built packages
-conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF


### PR DESCRIPTION
[skip appveyor]

I removed `conda-build 2` on Linux and `OS X` to test if the long prefix is indeed the problem here.