### PR TITLE
Fix build to use libc++ on OSX

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,10 +79,6 @@ install:
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
-    - cmd: # install conda-build 2.x to build with a long prefix
-    - cmd: conda install --yes --quiet conda-build=2
-    - cmd: conda info
-
 # Skip .NET project specific build phase.
 build: off
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+
 # Install the yum requirements defined canonically in the
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line be updated

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,6 +44,10 @@ if [ `uname` == Darwin ]; then
         unset $x
     done
 
+    # for some reason this dir isn't created and breaks
+    # the build if it isn't there
+    mkdir src/3rdparty/webkit/Source/lib
+
     chmod +x configure
     ./configure -prefix $PREFIX \
                 -libdir $PREFIX/lib \
@@ -69,7 +73,7 @@ if [ `uname` == Darwin ]; then
                 -platform unsupported/macx-clang-libc++ \
                 -silent
 
-    make
+    make -j $CPU_COUNT
     make install
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -66,7 +66,7 @@ if [ `uname` == Darwin ]; then
                 -system-libjpeg \
                 -no-framework \
                 -arch `uname -m`\
-                -platform macx-clang-libc++
+                -platform unsupported/macx-clang-libc++
 
     make
     make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -66,7 +66,8 @@ if [ `uname` == Darwin ]; then
                 -system-libjpeg \
                 -no-framework \
                 -arch `uname -m`\
-                -platform unsupported/macx-clang-libc++
+                -platform unsupported/macx-clang-libc++ \
+                -silent
 
     make
     make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-if [ $(uname) == Darwin ]; then
-    export CC=clang
-    export CXX=clang++
-    export MACOSX_DEPLOYMENT_TARGET="10.9"
-    export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
-    export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
-fi
-
-
 # Compile
 # -------
 chmod +x configure
@@ -75,7 +66,7 @@ if [ `uname` == Darwin ]; then
                 -system-libjpeg \
                 -no-framework \
                 -arch `uname -m`
-                #-platform macx-g++
+                -platform macx-clang-libc++
 
     make
     make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -65,7 +65,7 @@ if [ `uname` == Darwin ]; then
                 -system-libtiff \
                 -system-libjpeg \
                 -no-framework \
-                -arch `uname -m`
+                -arch `uname -m`\
                 -platform macx-clang-libc++
 
     make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,6 @@ source:
     - vs2015_int_fix.patch  # [win and py >= 35]
 
 build:
-  skip: True  # [osx or (win32 and py27) or (win and py34) or (win and py35)]
   number: 4
   features:
     - vc9  # [win and py27]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ source:
     # https://trac.macports.org/browser/trunk/dports/aqua/qt4-mac/files/patch-configure.diff
     - qmake-arch.patch  # [osx]
 
+    # Set the minimum deployment target to 10.9
+    - osx_deployment_target_10.9_qmake.conf.patch  # [osx]
+
     # Make Qt work with Ubuntu modifications to scrollbars for Gtk
     - ubuntu_disable_scrollbars.patch  # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,10 @@ source:
     # Set the minimum deployment target to 10.9
     - osx_deployment_target_10.9_qmake.conf.patch  # [osx]
 
+    # fix use of deprecated OSX API. Taken from Homebrew:
+    # https://github.com/Homebrew/legacy-homebrew/issues/40585
+    - qpaintengine_mac.patch  # [osx]
+
     # Make Qt work with Ubuntu modifications to scrollbars for Gtk
     - ubuntu_disable_scrollbars.patch  # [linux]
 

--- a/recipe/osx_deployment_target_10.9_qmake.conf.patch
+++ b/recipe/osx_deployment_target_10.9_qmake.conf.patch
@@ -1,11 +1,14 @@
---- mkspecs/unsupported/macx-clang-libc++/qmake.conf.orig	2016-12-15 17:35:03.484934790 +1000
-+++ mkspecs/unsupported/macx-clang-libc++/qmake.conf	2016-12-15 17:36:39.420938178 +1000
-@@ -13,7 +13,7 @@
+--- mkspecs/unsupported/macx-clang-libc++/qmake.conf.orig	2016-12-16 17:03:27.000000000 +1000
++++ mkspecs/unsupported/macx-clang-libc++/qmake.conf	2016-12-16 17:04:09.000000000 +1000
+@@ -13,7 +13,10 @@
  include(../../common/gcc-base-macx.conf)
  include(../../common/clang.conf)
  
 -QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7 # Libc++ is available from 10.7 onwards
 +QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9  # conda-forge minimum
++# set rpath ability - is unset otherwise for this platform and means
++# we can't set the rpath for the test
++QMAKE_LFLAGS_RPATH = "-Xlinker -rpath "
  
  QMAKE_CFLAGS += -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
  QMAKE_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET

--- a/recipe/osx_deployment_target_10.9_qmake.conf.patch
+++ b/recipe/osx_deployment_target_10.9_qmake.conf.patch
@@ -1,0 +1,11 @@
+--- mkspecs/unsupported/macx-clang-libc++/qmake.conf.orig	2016-12-15 17:35:03.484934790 +1000
++++ mkspecs/unsupported/macx-clang-libc++/qmake.conf	2016-12-15 17:36:39.420938178 +1000
+@@ -13,7 +13,7 @@
+ include(../../common/gcc-base-macx.conf)
+ include(../../common/clang.conf)
+ 
+-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7 # Libc++ is available from 10.7 onwards
++QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9  # conda-forge minimum
+ 
+ QMAKE_CFLAGS += -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
+ QMAKE_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET

--- a/recipe/qpaintengine_mac.patch
+++ b/recipe/qpaintengine_mac.patch
@@ -1,0 +1,17 @@
+--- a/src/gui/painting/qpaintengine_mac.cpp	2015-05-07 07:14:43.000000000 -0700
++++ b/src/gui/painting/qpaintengine_mac.cpp	2015-07-06 18:07:52.000000000 -0700
+@@ -340,13 +340,7 @@
+     }
+ 
+     // Get the color space from the display profile.
+-    CGColorSpaceRef colorSpace = 0;
+-    CMProfileRef displayProfile = 0;
+-    CMError err = CMGetProfileByAVID((CMDisplayIDType)displayID, &displayProfile);
+-    if (err == noErr) {
+-        colorSpace = CGColorSpaceCreateWithPlatformColorSpace(displayProfile);
+-        CMCloseProfile(displayProfile);
+-    }
++    CGColorSpaceRef colorSpace = CGDisplayCopyColorSpace(displayID);
+ 
+     // Fallback: use generic DeviceRGB
+     if (colorSpace == 0)

--- a/recipe/test/hello.pro
+++ b/recipe/test/hello.pro
@@ -5,3 +5,5 @@ CONFIG   += console
 CONFIG   -= app_bundle
 TEMPLATE = app
 SOURCES += main.cpp
+# so it can find the Qt libraries
+QMAKE_RPATHDIR += $$(PREFIX)/lib

--- a/recipe/test/hello.pro
+++ b/recipe/test/hello.pro
@@ -5,5 +5,12 @@ CONFIG   += console
 CONFIG   -= app_bundle
 TEMPLATE = app
 SOURCES += main.cpp
+
+# this is set in the qmake.conf for macx-clang-c++, but gets forgotten
+# somehow
+macx {
+    QMAKE_LFLAGS_RPATH = "-Xlinker -rpath "
+}
+
 # so it can find the Qt libraries
 QMAKE_RPATHDIR += $$(PREFIX)/lib


### PR DESCRIPTION
xref: #15 

This PR ensures that Qt is linked to `libc++` the same as other conda-forge packages. `pyqt` will need to be rebuilt once these packages are uploaded to be compatible.

I had to use the unsupported `macx-clang-libc++` Qt target, but seemed to work fine. I also had to add add another patch so I could compile with OSX 10.11 which is what I'm running here. I had to downgrade conda-build to 1.x since there are compile errors with 2.x (The prefix is too long to store in the arrays Qt creates).

Currently, I get a failing test:
```
clang++ -headerpad_max_install_names -stdlib=libc++ -mmacosx-version-min=10.9 -arch x86_64 -o hello main.o    -L/Users/sam/miniconda3/envs/_test/lib -lQtCore -L/Users/sam/miniconda3/envs/_test/lib 
+ ./hello
dyld: Library not loaded: @rpath/libQtCore.4.dylib
  Referenced from: /Users/sam/miniconda3/conda-bld/test-tmp_dir/test/./hello
  Reason: image not found
/Users/sam/miniconda3/conda-bld/test-tmp_dir/run_test.sh: line 6:   685 Trace/BPT trap: 5       ./hello
TESTS FAILED: qt-4.8.7-4
```
Seems like $DYLD_LIBRARY_PATH or the `rpath` should be set before running `hello`. Any ideas?

Below are the linkages:
```
$ otool -L ~/miniconda3/envs/tqt/lib/libQtCore.dylib 
/Users/sam/miniconda3/envs/tqt/lib/libQtCore.dylib:
	@rpath/libQtCore.4.dylib (compatibility version 4.8.0, current version 4.8.7)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices (compatibility version 1.0.0, current version 48.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.0.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 57337.60.2)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 728.13.0)
$ otool -L ~/miniconda3/envs/tqt/lib/libQtGui.dylib 
/Users/sam/miniconda3/envs/tqt/lib/libQtGui.dylib:
	@rpath/libQtGui.4.dylib (compatibility version 4.8.0, current version 4.8.7)
	@rpath/libQtCore.4.dylib (compatibility version 4.8.0, current version 4.8.7)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 157.0.0)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1404.47.0)
	@rpath/libpng16.16.dylib (compatibility version 43.0.0, current version 43.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices (compatibility version 1.0.0, current version 48.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.0.0)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 600.0.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 728.13.0)
	/System/Library/Frameworks/CoreText.framework/Versions/A/CoreText (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1259.0.0)
	/System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```