### PR TITLE
Fix compilation under conda-build 2.x

### DIFF
--- a/recipe/config.cpp.longpath.patch
+++ b/recipe/config.cpp.longpath.patch
@@ -1,0 +1,135 @@
+--- configure.orig	2016-12-27 11:44:32.000000000 +1000
++++ configure	2016-12-27 11:47:05.000000000 +1000
+@@ -4766,26 +4766,26 @@
+ #-------------------------------------------------------------------------------
+ [ -d "$outpath/src/corelib/global" ] || mkdir -p "$outpath/src/corelib/global"
+ 
+-LICENSE_USER_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_lcnsuser=$Licensee"`
+-LICENSE_PRODUCTS_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_lcnsprod=$Edition"`
+-PREFIX_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_prfxpath=$QT_INSTALL_PREFIX"`
+-DOCUMENTATION_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_docspath=$QT_INSTALL_DOCS"`
+-HEADERS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_hdrspath=$QT_INSTALL_HEADERS"`
+-LIBRARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_libspath=$QT_INSTALL_LIBS"`
+-BINARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_binspath=$QT_INSTALL_BINS"`
+-PLUGINS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_plugpath=$QT_INSTALL_PLUGINS"`
+-IMPORTS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_impspath=$QT_INSTALL_IMPORTS"`
+-DATA_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_datapath=$QT_INSTALL_DATA"`
+-TRANSLATIONS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_trnspath=$QT_INSTALL_TRANSLATIONS"`
+-SETTINGS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_stngpath=$QT_INSTALL_SETTINGS"`
+-EXAMPLES_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_xmplpath=$QT_INSTALL_EXAMPLES"`
+-DEMOS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_demopath=$QT_INSTALL_DEMOS"`
++LICENSE_USER_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_lcnsuser=$Licensee"`
++LICENSE_PRODUCTS_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_lcnsprod=$Edition"`
++PREFIX_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_prfxpath=$QT_INSTALL_PREFIX"`
++DOCUMENTATION_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_docspath=$QT_INSTALL_DOCS"`
++HEADERS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_hdrspath=$QT_INSTALL_HEADERS"`
++LIBRARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_libspath=$QT_INSTALL_LIBS"`
++BINARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_binspath=$QT_INSTALL_BINS"`
++PLUGINS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_plugpath=$QT_INSTALL_PLUGINS"`
++IMPORTS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_impspath=$QT_INSTALL_IMPORTS"`
++DATA_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_datapath=$QT_INSTALL_DATA"`
++TRANSLATIONS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_trnspath=$QT_INSTALL_TRANSLATIONS"`
++SETTINGS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_stngpath=$QT_INSTALL_SETTINGS"`
++EXAMPLES_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_xmplpath=$QT_INSTALL_EXAMPLES"`
++DEMOS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_demopath=$QT_INSTALL_DEMOS"`
+ 
+ TODAY=`date +%Y-%m-%d`
+ cat > "$outpath/src/corelib/global/qconfig.cpp.new" <<EOF
+ /* License Info */
+-static const char qt_configure_licensee_str          [256 + 12] = "$LICENSE_USER_STR";
+-static const char qt_configure_licensed_products_str [256 + 12] = "$LICENSE_PRODUCTS_STR";
++static const char qt_configure_licensee_str          [356 + 12] = "$LICENSE_USER_STR";
++static const char qt_configure_licensed_products_str [356 + 12] = "$LICENSE_PRODUCTS_STR";
+ 
+ /* Installation date */
+ static const char qt_configure_installation          [12+11]    = "qt_instdate=$TODAY";
+@@ -4793,53 +4793,53 @@
+ 
+ 
+ if [ ! -z "$QT_HOST_PREFIX" ]; then
+-    HOSTPREFIX_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_prfxpath=$QT_HOST_PREFIX"`
+-    HOSTDOCUMENTATION_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_docspath=$QT_HOST_PREFIX/doc"`
+-    HOSTHEADERS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_hdrspath=$QT_HOST_PREFIX/include"`
+-    HOSTLIBRARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_libspath=$QT_HOST_PREFIX/lib"`
+-    HOSTBINARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_binspath=$QT_HOST_PREFIX/bin"`
+-    HOSTPLUGINS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_plugpath=$QT_HOST_PREFIX/plugins"`
+-    HOSTIMPORTS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_impspath=$QT_HOST_PREFIX/IMPORTS"`
+-    HOSTDATA_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_datapath=$QT_HOST_PREFIX"`
+-    HOSTTRANSLATIONS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_trnspath=$QT_HOST_PREFIX/translations"`
+-    HOSTSETTINGS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_stngpath=$QT_INSTALL_SETTINGS"`
+-    HOSTEXAMPLES_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_xmplpath=$QT_INSTALL_EXAMPLES"`
+-    HOSTDEMOS_PATH_STR=`"$relpath/config.tests/unix/padstring" 268 "qt_demopath=$QT_INSTALL_DEMOS"`
++    HOSTPREFIX_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_prfxpath=$QT_HOST_PREFIX"`
++    HOSTDOCUMENTATION_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_docspath=$QT_HOST_PREFIX/doc"`
++    HOSTHEADERS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_hdrspath=$QT_HOST_PREFIX/include"`
++    HOSTLIBRARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_libspath=$QT_HOST_PREFIX/lib"`
++    HOSTBINARIES_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_binspath=$QT_HOST_PREFIX/bin"`
++    HOSTPLUGINS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_plugpath=$QT_HOST_PREFIX/plugins"`
++    HOSTIMPORTS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_impspath=$QT_HOST_PREFIX/IMPORTS"`
++    HOSTDATA_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_datapath=$QT_HOST_PREFIX"`
++    HOSTTRANSLATIONS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_trnspath=$QT_HOST_PREFIX/translations"`
++    HOSTSETTINGS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_stngpath=$QT_INSTALL_SETTINGS"`
++    HOSTEXAMPLES_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_xmplpath=$QT_INSTALL_EXAMPLES"`
++    HOSTDEMOS_PATH_STR=`"$relpath/config.tests/unix/padstring" 368 "qt_demopath=$QT_INSTALL_DEMOS"`
+ 
+     cat >> "$outpath/src/corelib/global/qconfig.cpp.new" <<EOF
+ 
+ #if defined(QT_BOOTSTRAPPED) || defined(QT_BUILD_QMAKE)
+ /* Installation Info */
+-static const char qt_configure_prefix_path_str       [256 + 12] = "$HOSTPREFIX_PATH_STR";
+-static const char qt_configure_documentation_path_str[256 + 12] = "$HOSTDOCUMENTATION_PATH_STR";
+-static const char qt_configure_headers_path_str      [256 + 12] = "$HOSTHEADERS_PATH_STR";
+-static const char qt_configure_libraries_path_str    [256 + 12] = "$HOSTLIBRARIES_PATH_STR";
+-static const char qt_configure_binaries_path_str     [256 + 12] = "$HOSTBINARIES_PATH_STR";
+-static const char qt_configure_plugins_path_str      [256 + 12] = "$HOSTPLUGINS_PATH_STR";
+-static const char qt_configure_imports_path_str      [256 + 12] = "$HOSTIMPORTS_PATH_STR";
+-static const char qt_configure_data_path_str         [256 + 12] = "$HOSTDATA_PATH_STR";
+-static const char qt_configure_translations_path_str [256 + 12] = "$HOSTTRANSLATIONS_PATH_STR";
+-static const char qt_configure_settings_path_str     [256 + 12] = "$HOSTSETTINGS_PATH_STR";
+-static const char qt_configure_examples_path_str     [256 + 12] = "$HOSTEXAMPLES_PATH_STR";
+-static const char qt_configure_demos_path_str        [256 + 12] = "$HOSTDEMOS_PATH_STR";
++static const char qt_configure_prefix_path_str       [356 + 12] = "$HOSTPREFIX_PATH_STR";
++static const char qt_configure_documentation_path_str[356 + 12] = "$HOSTDOCUMENTATION_PATH_STR";
++static const char qt_configure_headers_path_str      [356 + 12] = "$HOSTHEADERS_PATH_STR";
++static const char qt_configure_libraries_path_str    [356 + 12] = "$HOSTLIBRARIES_PATH_STR";
++static const char qt_configure_binaries_path_str     [356 + 12] = "$HOSTBINARIES_PATH_STR";
++static const char qt_configure_plugins_path_str      [356 + 12] = "$HOSTPLUGINS_PATH_STR";
++static const char qt_configure_imports_path_str      [356 + 12] = "$HOSTIMPORTS_PATH_STR";
++static const char qt_configure_data_path_str         [356 + 12] = "$HOSTDATA_PATH_STR";
++static const char qt_configure_translations_path_str [356 + 12] = "$HOSTTRANSLATIONS_PATH_STR";
++static const char qt_configure_settings_path_str     [356 + 12] = "$HOSTSETTINGS_PATH_STR";
++static const char qt_configure_examples_path_str     [356 + 12] = "$HOSTEXAMPLES_PATH_STR";
++static const char qt_configure_demos_path_str        [356 + 12] = "$HOSTDEMOS_PATH_STR";
+ #else // QT_BOOTSTRAPPED
+ EOF
+ fi
+ 
+ cat >> "$outpath/src/corelib/global/qconfig.cpp.new" <<EOF
+ /* Installation Info */
+-static const char qt_configure_prefix_path_str       [256 + 12] = "$PREFIX_PATH_STR";
+-static const char qt_configure_documentation_path_str[256 + 12] = "$DOCUMENTATION_PATH_STR";
+-static const char qt_configure_headers_path_str      [256 + 12] = "$HEADERS_PATH_STR";
+-static const char qt_configure_libraries_path_str    [256 + 12] = "$LIBRARIES_PATH_STR";
+-static const char qt_configure_binaries_path_str     [256 + 12] = "$BINARIES_PATH_STR";
+-static const char qt_configure_plugins_path_str      [256 + 12] = "$PLUGINS_PATH_STR";
+-static const char qt_configure_imports_path_str      [256 + 12] = "$IMPORTS_PATH_STR";
+-static const char qt_configure_data_path_str         [256 + 12] = "$DATA_PATH_STR";
+-static const char qt_configure_translations_path_str [256 + 12] = "$TRANSLATIONS_PATH_STR";
+-static const char qt_configure_settings_path_str     [256 + 12] = "$SETTINGS_PATH_STR";
+-static const char qt_configure_examples_path_str     [256 + 12] = "$EXAMPLES_PATH_STR";
+-static const char qt_configure_demos_path_str        [256 + 12] = "$DEMOS_PATH_STR";
++static const char qt_configure_prefix_path_str       [356 + 12] = "$PREFIX_PATH_STR";
++static const char qt_configure_documentation_path_str[356 + 12] = "$DOCUMENTATION_PATH_STR";
++static const char qt_configure_headers_path_str      [356 + 12] = "$HEADERS_PATH_STR";
++static const char qt_configure_libraries_path_str    [356 + 12] = "$LIBRARIES_PATH_STR";
++static const char qt_configure_binaries_path_str     [356 + 12] = "$BINARIES_PATH_STR";
++static const char qt_configure_plugins_path_str      [356 + 12] = "$PLUGINS_PATH_STR";
++static const char qt_configure_imports_path_str      [356 + 12] = "$IMPORTS_PATH_STR";
++static const char qt_configure_data_path_str         [356 + 12] = "$DATA_PATH_STR";
++static const char qt_configure_translations_path_str [356 + 12] = "$TRANSLATIONS_PATH_STR";
++static const char qt_configure_settings_path_str     [356 + 12] = "$SETTINGS_PATH_STR";
++static const char qt_configure_examples_path_str     [356 + 12] = "$EXAMPLES_PATH_STR";
++static const char qt_configure_demos_path_str        [356 + 12] = "$DEMOS_PATH_STR";
+ EOF
+ 
+ if [ ! -z "$QT_HOST_PREFIX" ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
     # Make Qt accept its open source license without user interaction
     - acceptance.patch
 
+    # Make the paths in config.cpp longer so they work with conda-build 2.x
+    - config.cpp.longpath.patch  # [unix]
+
     # Compile qmake with the system architecture. Taken from the MacPorts project:
     # https://trac.macports.org/browser/trunk/dports/aqua/qt4-mac/files/patch-configure.diff
     - qmake-arch.patch  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,10 @@ source:
     # Set the minimum deployment target to 10.9
     - osx_deployment_target_10.9_qmake.conf.patch  # [osx]
 
+    # Enabling our test to set the rpath by making Qt aware
+    # of how to do this on OSX
+    - osx_rpath.qmake.conf.patch  # [osx]
+
     # fix use of deprecated OSX API. Taken from Homebrew:
     # https://github.com/Homebrew/legacy-homebrew/issues/40585
     - qpaintengine_mac.patch  # [osx]

--- a/recipe/osx_deployment_target_10.9_qmake.conf.patch
+++ b/recipe/osx_deployment_target_10.9_qmake.conf.patch
@@ -1,14 +1,11 @@
---- mkspecs/unsupported/macx-clang-libc++/qmake.conf.orig	2016-12-16 17:03:27.000000000 +1000
-+++ mkspecs/unsupported/macx-clang-libc++/qmake.conf	2016-12-16 17:04:09.000000000 +1000
-@@ -13,7 +13,10 @@
+--- mkspecs/unsupported/macx-clang-libc++/qmake.conf.orig	2016-12-27 12:51:31.000000000 +1000
++++ mkspecs/unsupported/macx-clang-libc++/qmake.conf	2016-12-27 12:52:13.000000000 +1000
+@@ -13,7 +13,7 @@
  include(../../common/gcc-base-macx.conf)
  include(../../common/clang.conf)
  
 -QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7 # Libc++ is available from 10.7 onwards
-+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9  # conda-forge minimum
-+# set rpath ability - is unset otherwise for this platform and means
-+# we can't set the rpath for the test
-+QMAKE_LFLAGS_RPATH = "-Xlinker -rpath "
++QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9 # conda-forge minimum
  
  QMAKE_CFLAGS += -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
  QMAKE_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET

--- a/recipe/osx_rpath.qmake.conf.patch
+++ b/recipe/osx_rpath.qmake.conf.patch
@@ -1,0 +1,11 @@
+--- mkspecs/common/mac.conf.orig	2016-12-27 12:52:58.000000000 +1000
++++ mkspecs/common/mac.conf	2016-12-27 12:53:28.000000000 +1000
+@@ -14,7 +14,7 @@
+ 
+ QMAKE_FIX_RPATH         = install_name_tool -id 
+ 
+-QMAKE_LFLAGS_RPATH	=
++QMAKE_LFLAGS_RPATH	= -Xlinker -rpath$$LITERAL_WHITESPACE
+ 
+ QMAKE_LIBS_DYNLOAD	=
+ QMAKE_LIBS_OPENGL	= -framework OpenGL -framework AGL

--- a/recipe/test/hello.pro
+++ b/recipe/test/hello.pro
@@ -5,12 +5,5 @@ CONFIG   += console
 CONFIG   -= app_bundle
 TEMPLATE = app
 SOURCES += main.cpp
-
-# this is set in the qmake.conf for macx-clang-c++, but gets forgotten
-# somehow
-macx {
-    QMAKE_LFLAGS_RPATH = "-Xlinker -rpath "
-}
-
 # so it can find the Qt libraries
 QMAKE_RPATHDIR += $$(PREFIX)/lib


### PR DESCRIPTION
This PR fixes compilation under `conda-build` 2.x for Unix. It also tidies up the `rpath` work from my last PR which I didn't quite have worked out then.