### PR TITLE
set $QMAKESPEC on OSX using an activate script

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -75,6 +75,16 @@ if [ $(uname) == Darwin ]; then
 
     make -j $CPU_COUNT
     make install
+
+    # copy activation scripts for OSX - set $QMAKESPEC
+    # to unsupported/macx-clang-libc++ otherwise there are problems with qmake
+    ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+    DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
+    mkdir -p $ACTIVATE_DIR
+    mkdir -p $DEACTIVATE_DIR
+
+    cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/qt-activate.sh
+    cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/qt-deactivate.sh
 fi
 
 

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 if [[ -n "$QMAKESPEC" ]]; then
     export _CONDA_SET_QMAKESPEC=$QMAKESPEC

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,0 +1,5 @@
+
+if [[ -n "$QMAKESPEC" ]]; then
+    export _CONDA_SET_QMAKESPEC=$QMAKESPEC
+fi
+export QMAKESPEC=unsupported/macx-clang-libc++

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,0 +1,6 @@
+
+unset QMAKESPEC
+if [[ -n "$_CONDA_SET_QMAKESPEC" ]]; then
+    export QMAKESPEC=$_CONDA_SET_QMAKESPEC
+    unset _CONDA_SET_QMAKESPEC
+fi

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 unset QMAKESPEC
 if [[ -n "$_CONDA_SET_QMAKESPEC" ]]; then


### PR DESCRIPTION
This fixes the problem on OSX where building the test `hello.pro` with `qmake` fails since the paths for the default spec are incorrect because they got copied from the `unsupported` folder. This PR tells `qmake` what spec to use via the $QMAKESPEC environment variable which seems the documented way to set this. This should also mean that other packages using `qmake` get the correct spec.