### PR TITLE
Add xorg-x11-server-Xvfb for X server test...

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -46,10 +48,32 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line be updated
 # automatically.
-yum install -y libX11-devel libXt-devel libXext-devel chrpath libXrender-devel gtk2-devel dbus-devel libSM-devel libICE-devel
+yum install -y libX11-devel libXt-devel libXext-devel chrpath libXrender-devel gtk2-devel dbus-devel libSM-devel libICE-devel xorg-x11-server-Xvfb
 
 
-# Embarking on 1 case(s).
+# Embarking on 3 case(s).
+    set -x
+    export CONDA_PERL=5.20.3.1
+    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PERL=5.22.0.1
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PERL=5.22.2.1
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -51,19 +51,7 @@ source run_conda_forge_build_setup
 yum install -y libX11-devel libXt-devel libXext-devel chrpath libXrender-devel gtk2-devel dbus-devel libSM-devel libICE-devel xorg-x11-server-Xvfb
 
 
-# Embarking on 3 case(s).
-    set -x
-    export CONDA_PERL=5.20.3.1
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PERL=5.22.0.1
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
+# Embarking on 1 case(s).
     set -x
     export CONDA_PERL=5.22.2.1
     set +x

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0008-disable-Ubuntu-overlay-scrollbars-as-they-don-t-play.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx or win]
   detect_binary_files_with_prefix: true
   features:
@@ -34,7 +34,7 @@ requirements:
     - zlib 1.2.*
     - libpng >=1.6.28,<1.7
     - gst-plugins-base
-    - icu 56.*
+    - icu 58.*
     - libxcb
     - dbus
     - vc 9  # [win and py27]
@@ -48,7 +48,7 @@ requirements:
     - zlib 1.2.*
     - libpng >=1.6.28,<1.7
     - gst-plugins-base
-    - icu 56.*
+    - icu 58.*
     - libxcb
     - dbus
     - vc 9  # [win and py27]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - python  # [win]
-    - perl
+    - perl 5.22.2.1
     - freetype 2.7|2.7.*
     - fontconfig 2.12.*
     - openssl 1.0.*

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -7,3 +7,4 @@ gtk2-devel
 dbus-devel
 libSM-devel
 libICE-devel
+xorg-x11-server-Xvfb


### PR DESCRIPTION
... and update the ICU pin so we can try it with the rest of the package stack later.

Note that we cannot move to `Qt5` yet since we still don't have `Windows` and `OS X` build. Both should break the time limit and volunteers will be needed to build locally and upload the packages (unless we reach an agreement with regards the pinnings with `defaults` :grimacing:).