### PR TITLE
Build with SDK 10.9

### DIFF
--- a/recipe/0009-osx-force-10.9-deployment-target.patch
+++ b/recipe/0009-osx-force-10.9-deployment-target.patch
@@ -1,0 +1,10 @@
+--- qtbase/mkspecs/macx-clang/qmake.conf
++++ qtbase/mkspecs/macx-clang/qmake.conf
+@@ -11,6 +11,6 @@
+ include(../common/clang.conf)
+ include(../common/clang-mac.conf)
+ 
+-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
++QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+ 
+ load(qt_config)

--- a/recipe/0010-osx-xctest-check.patch
+++ b/recipe/0010-osx-xctest-check.patch
@@ -1,0 +1,11 @@
+--- qtbase/src/testlib/testlib.pro
++++ qtbase/src/testlib/testlib.pro
+@@ -83,7 +83,7 @@
+     }
+ 
+     # XCTest support
+-    !lessThan(QMAKE_XCODE_VERSION, "6.0") {
++    !lessThan(QMAKE_XCODE_VERSION, "6.0"):!lessThan(QMAKE_DEPLOYMENT_TARGET, "10.10") {
+         OBJECTIVE_SOURCES += qxctestlogger.mm
+         HEADERS += qxctestlogger_p.h
+ 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -127,7 +127,9 @@ if [ $(uname) == Darwin ]; then
                 -no-xcb-xlib \
                 -no-libudev \
                 -no-egl \
-                -no-openssl
+                -no-openssl \
+                -sdk macosx10.9 \
+    ####
 
     make -j $CPU_COUNT || exit 1
     make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
     - 0008-disable-Ubuntu-overlay-scrollbars-as-they-don-t-play.patch
     # qtbase
     - 0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch  # [win]
+    - 0009-osx-force-10.9-deployment-target.patch  # [osx]
     # qt3d
     - 0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch  # [win]
     # qtwinextras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,3 +92,4 @@ extra:
     - gillins
     - msarahan
     - ocefpaf
+    - stuarteberg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
     # qtbase
     - 0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch  # [win]
     - 0009-osx-force-10.9-deployment-target.patch  # [osx]
+    - 0010-osx-xctest-check.patch  # [osx]
     # qt3d
     - 0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch  # [win]
     # qtwinextras


### PR DESCRIPTION
Build with the `10.9` SDK, assuming it's available.  These changes were previously explained here: https://github.com/conda-forge/qt-feedstock/pull/35#issuecomment-293406362.
