### PR TITLE
Fix phonon linking for Qt4 on OSX

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ source:
     # found in forums, and originated at (Author appears to be Peter Zhigalov):
     # https://fami.codefreak.ru/gitlab/peter/qt4/commit/45e8f4eef3923e03c6939d0c17170980685857ef.diff
     - vs2015_int_fix.patch  # [win and py >= 35]
+    # see https://bugreports.qt.io/browse/QTBUG-37209
+    # fix phonon exports so they can be linked to
+    - phonon_osx_exports.patch  # [osx]
 
 build:
   number: 7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,8 @@ source:
     - phonon_osx_exports.patch  # [osx]
 
 build:
-  number: 7
+  number: 7  # [linux or win]
+  number: 8  # [osx]
   skip: True  # [osx or (win and py>35)]
   features:
     - vc9  # [win and py27]

--- a/recipe/phonon_osx_exports.patch
+++ b/recipe/phonon_osx_exports.patch
@@ -1,0 +1,29 @@
+--- src/3rdparty/phonon/phonon/objectdescriptionmodel.h.orig	2017-04-11 15:06:13.000000000 +1000
++++ src/3rdparty/phonon/phonon/objectdescriptionmodel.h	2017-04-11 15:07:26.000000000 +1000
+@@ -141,16 +141,19 @@
+ 
+ /* Required to ensure template class vtables are exported on both symbian
+ and existing builds. */
+-#if (defined(Q_OS_SYMBIAN) && defined(Q_CC_RVCT)) || defined(Q_CC_CLANG)
+-// RVCT compiler (2.2.686) requires the export declaration to be on the class to export vtables
+-// MWC compiler works both ways
+-// GCCE compiler is unknown (it can't compile QtCore yet)
+-// Clang also requires the export declaration to be on the class to export vtables
++#if defined(Q_OS_SYMBIAN) && defined(Q_CC_RVCT)
++// RVCT compiler (2.2.686) requires the export declaration to be on the class to export vtables 
++// MWC compiler works both ways 
++// GCCE compiler is unknown (it can't compile QtCore yet) 
++// Clang also requires the export declaration to be on the class to export vtables 
+ #define PHONON_TEMPLATE_CLASS_EXPORT PHONON_EXPORT
+ #define PHONON_TEMPLATE_CLASS_MEMBER_EXPORT
++#elif defined(Q_CC_CLANG)
++#define PHONON_TEMPLATE_CLASS_EXPORT
++#define PHONON_TEMPLATE_CLASS_MEMBER_EXPORT PHONON_EXPORT
+ #else
+-// Windows builds (at least) do not support export declaration on templated class
+-// But if you export a member function, the vtable is implicitly exported
++// Windows builds (at least) do not support export declaration on templated class 
++// But if you export a member function, the vtable is implicitly exported 
+ #define PHONON_TEMPLATE_CLASS_EXPORT
+ #define PHONON_TEMPLATE_CLASS_MEMBER_EXPORT PHONON_EXPORT
+ #endif


### PR DESCRIPTION
This PR fixes `pyside` linking to phonon. I was able to remove the `-E phonon` part from `pyside`'s `build.sh` and it build and tested fine.

See https://github.com/conda-forge/qt-feedstock/issues/34

I was unable to test `pyqt` due to https://github.com/conda-forge/pyqt-feedstock/issues/20