### PR TITLE
Mac build requires Python 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ build:
 requirements:
   build:
     - python  # [win]
+    - python 2.7*  # [osx]
     - 7za  # [win]
     - curl  # [win]
     - msinttypes  # [win and py27]


### PR DESCRIPTION
...since chromium doesn't build without it