### PR TITLE
Qt4: On mac, configure with the 10.9 SDK

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,6 +44,8 @@ if [ $(uname) == Darwin ]; then
         unset $x
     done
 
+    export MACOSX_DEPLOYMENT_TARGET="10.9"
+
     # for some reason this dir isn't created and breaks
     # the build if it isn't there
     mkdir src/3rdparty/webkit/Source/lib
@@ -71,7 +73,9 @@ if [ $(uname) == Darwin ]; then
                 -no-framework \
                 -arch $(uname -m) \
                 -platform unsupported/macx-clang-libc++ \
-                -silent
+                -silent \
+                -sdk $(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk \
+    ####
 
     make -j $CPU_COUNT
     make install


### PR DESCRIPTION
(This PR follows up on the discussion in #36, starting here: https://github.com/conda-forge/qt-feedstock/pull/36#issuecomment-294006768.)

On my machine**, our Qt4 recipe doesn't use the 10.9 SDK, despite the fact that we set `QMAKE_DEPLOYMENT_TARGET = 10.9`.

The fix I is to provide the `-sdk` argument to `configure`:

```
configure [...] -sdk $(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk
```

The resulting package, built with these changes, can be found on my channel:
https://anaconda.org/stuarteberg/qt/4.8.7/download/osx-64/qt-4.8.7-8.tar.bz2

(BTW, I **briefly** verified that my build works with Spyder.)

** macOS 10.12 Sierra, Xcode 8.3