### PR TITLE
Remove unneeded dependencies in macOS

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -113,11 +113,11 @@ if [ $(uname) == Darwin ]; then
                 -skip wayland \
                 -skip canvas3d \
                 -skip 3d \
+                -system-freetype \
+                -system-libjpeg \
+                -system-libpng \
                 -system-zlib \
                 -qt-pcre \
-                -qt-freetype \
-                -qt-libjpeg \
-                -qt-libpng \
                 -c++11 \
                 -no-framework \
                 -no-dbus \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ source:
     - 0001-shobjidl-Fix-compile-guard-around-SHARDAPPIDINFOLINK.patch  # [win]
 
 build:
-  number: 1  # [osx or win]
-  number: 2  # [linux]
+  number: 1  # [win]
+  number: 2  # [unix]
   skip: True  # [osx or win or linux]
   detect_binary_files_with_prefix: true
   features:
@@ -43,7 +43,7 @@ requirements:
     - curl  # [win]
     - msinttypes  # [win and py27]
     - perl 5.22.2.1
-    - freetype 2.7|2.7.*  # [linux]
+    - freetype 2.7|2.7.*  # [unix]
     - fontconfig 2.12.*  # [linux]
     - openssl 1.0.*  # [not osx]
     - jpeg 9*
@@ -57,7 +57,7 @@ requirements:
     - vc 10  # [win and py34]
     - vc 14  # [win and py>=35]
   run:
-    - freetype 2.7|2.7.*  # [linux]
+    - freetype 2.7|2.7.*  # [unix]
     - fontconfig 2.12.*  # [linux]
     - openssl 1.0.*  # [not osx]
     - jpeg 9*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,30 +43,30 @@ requirements:
     - curl  # [win]
     - msinttypes  # [win and py27]
     - perl 5.22.2.1
-    - freetype 2.7|2.7.*  # [unix]
+    - freetype 2.7|2.7.*  # [linux]
     - fontconfig 2.12.*  # [linux]
-    - openssl 1.0.*
+    - openssl 1.0.*  # [not osx]
     - jpeg 9*
     - zlib 1.2.*
     - libpng >=1.6.28,<1.7
     - gst-plugins-base  # [linux]
     - icu 58.*
     - libxcb  # [linux]
-    - dbus  # [unix]
+    - dbus  # [linux]
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]
     - vc 14  # [win and py>=35]
   run:
-    - freetype 2.7|2.7.*  # [unix]
+    - freetype 2.7|2.7.*  # [linux]
     - fontconfig 2.12.*  # [linux]
-    - openssl 1.0.*
+    - openssl 1.0.*  # [not osx]
     - jpeg 9*
     - zlib 1.2.*
     - libpng >=1.6.28,<1.7
     - gst-plugins-base  # [linux]
     - icu 58.*
     - libxcb  # [linux]
-    - dbus  # [unix]
+    - dbus  # [linux]
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]
     - vc 14  # [win and py>=35]


### PR DESCRIPTION
Fixes #41 

----

@stuarteberg, we need your help for a recompilation here. Thanks!

I'll leave this PR open in case you have problems and need to add more changes.

----

@ocefpaf, @jakirkham, please **stop** changing/touching dependencies for Qt5. It's clear you don't know when they are needed and when they aren't.

Examples for macOS:

* openssl is not needed since Qt 5.6. See https://github.com/Homebrew/legacy-homebrew/issues/42217#issuecomment-126379557
* You made the package to depend on system libraries (jpeg and libpng) but didn't change the configure options to make that happen.
* You made the package to depend on dbus when there's no need for that.

Examples for Linux:

* You didn't include bison, flex, gperf and ruby, even when they are listed in Continuum's recipe. That's the reason why QtWebKit was not built.

This only makes to waste my and the rest of maintainers time.