### PR TITLE
osx: Don't require users to build their apps with SDK 10.9

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -155,6 +155,11 @@ then
         mv ${BIN}/${name}.app ${BIN}/${name}app
     done
 
+    # We built Qt itself with SDK 10.9, but we shouldn't
+    # force users to also build their Qt apps with SDK 10.9
+    # https://bugreports.qt.io/browse/QTBUG-41238
+    sed -i '' s/macosx10\../macosx/g ${PREFIX}/mkspecs/qdevice.pri
+
     POST_LINK=$BIN/.qt-post-link.sh
     PRE_UNLINK=$BIN/.qt-pre-unlink.sh
     cp $RECIPE_DIR/osx-post.sh $POST_LINK

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -113,11 +113,11 @@ if [ $(uname) == Darwin ]; then
                 -skip wayland \
                 -skip canvas3d \
                 -skip 3d \
-                -system-freetype \
                 -system-libjpeg \
                 -system-libpng \
                 -system-zlib \
                 -qt-pcre \
+                -qt-freetype \
                 -c++11 \
                 -no-framework \
                 -no-dbus \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - curl  # [win]
     - msinttypes  # [win and py27]
     - perl 5.22.2.1
-    - freetype 2.7|2.7.*  # [unix]
+    - freetype 2.7|2.7.*  # [linux]
     - fontconfig 2.12.*  # [linux]
     - openssl 1.0.*  # [not osx]
     - jpeg 9*
@@ -58,7 +58,7 @@ requirements:
     - vc 10  # [win and py34]
     - vc 14  # [win and py>=35]
   run:
-    - freetype 2.7|2.7.*  # [unix]
+    - freetype 2.7|2.7.*  # [linux]
     - fontconfig 2.12.*  # [linux]
     - openssl 1.0.*  # [not osx]
     - jpeg 9*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ source:
 
 build:
   number: 1  # [win]
-  number: 3  # [unix]
+  number: 3  # [linux]
+  number: 4  # [osx]
   skip: True  # [osx or win or linux]
   detect_binary_files_with_prefix: true
   features:


### PR DESCRIPTION
On Mac, our Qt 5 package ships a slightly broken `mkspecs/qdevice.pri` file.  It requires users of qt to build with the same SDK that we built Qt itself with (i.e. 10.9).

One solution to this is explained here:
https://bugreports.qt.io/browse/QTBUG-41238

So I've added a line to `build.sh` to do just that.

BTW, I checked the Qt5 package on the `defaults` channel, and it seems not to suffer from this issue.  In fact, its `qdevice.pri` file doesn't have a `!host_build:` line at all.  I'm not sure if that's due to a difference in the way they built the package, or if they edit that file afterwards.