### PR TITLE
ensure build path is removed from $CXX etc so that qmake works

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -22,10 +22,12 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -81,4 +81,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -25,6 +25,14 @@ conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 run_conda_forge_build_setup
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y chrpath ruby
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -25,7 +25,7 @@ jpeg:
 libpng:
 - 1.6.35
 openssl:
-- 1.0.2
+- 1.1.1a
 perl:
 - '5.26'
 pin_run_as_build:

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -4,6 +4,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+curl:
+- '7.64'
 cxx_compiler:
 - gxx
 dbus:
@@ -27,6 +29,8 @@ openssl:
 perl:
 - '5.26'
 pin_run_as_build:
+  curl:
+    max_pin: x
   dbus:
     max_pin: x
   fontconfig:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -6,6 +6,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+curl:
+- '7.64'
 cxx_compiler:
 - clangxx
 icu:
@@ -21,6 +23,8 @@ macos_min_version:
 perl:
 - '5.26'
 pin_run_as_build:
+  curl:
+    max_pin: x
   icu:
     max_pin: x
   jpeg:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,16 @@ set -ex
 # -------
 chmod +x configure
 
+# Remove the full path from CXX etc. If we don't do this
+# then the full path at build time gets put into 
+# mkspecs/qmodule.pri and qmake attempts to use this.
+export AR=$(basename ${AR})
+export RANLIB=$(basename ${RANLIB})
+export STRIP=$(basename ${STRIP})
+export OBJDUMP=$(basename ${OBJDUMP})
+export CC=$(basename ${CC})
+export CXX=$(basename ${CXX})
+
 # Frustratingly, Qt's configure checks do not honor the standard build
 # environment variables ($CC, $*FLAGS, etc) in a very consistent way. In
 # particular, they are largely ignored during configuration. AFAICT, the best

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - 0001-shobjidl-Fix-compile-guard-around-SHARDAPPIDINFOLINK.patch  # [win]
 
 build:
-  number: 1013
+  number: 1014
   skip: True  # [ win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

As [suggested](https://github.com/conda-forge/qtlocation-feedstock/pull/3#issuecomment-466348938) by @mingwandroid ensure that the build path is removed and not baked into qt mkspecs files as this was breaking `qmake`.

Test package built with this recipe available on the `gillins` channel.
