### PR TITLE
System tiff

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -146,6 +146,7 @@ call configure ^
      -system-libjpeg ^
      -system-libpng ^
      -system-sqlite ^
+     -system-tiff ^
      -system-zlib ^
      -plugin-sql-sqlite ^
      -qtlibinfix %QT_LIBINFIX% ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -175,6 +175,7 @@ if [[ ${HOST} =~ .*linux.* ]]; then
                 -system-libpng \
                 -system-zlib \
                 -system-sqlite \
+                -system-tiff \
                 -plugin-sql-sqlite \
                 -qt-pcre \
                 -qt-xcb \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc != 14]
   detect_binary_files_with_prefix: true
   # QtWebEngine fails on Linux unless we merge
@@ -156,6 +156,7 @@ requirements:
     - icu
     - jpeg
     - libpng
+    - libtiff
     - nspr                               # [unix]
     - nss                                # [unix]
     - sqlite


### PR DESCRIPTION
Just a guess, I think qt somehow links to the framework lib on osx:

```
2019-08-08T18:20:11.1368170Z [ 16%] Built target QtCore
2019-08-08T18:20:11.1747710Z Scanning dependencies of target QtCore_pyi
2019-08-08T18:20:11.1790740Z [ 16%] Generating __/moc_qpytextobject.cpp
2019-08-08T18:20:11.4745410Z Traceback (most recent call last):
2019-08-08T18:20:11.4750970Z   File "/usr/local/miniconda/conda-bld/pyside2_1565287062358/work/sources/pyside2/PySide2/QtCore/../support/generate_pyi.py", line 290, in <module>
2019-08-08T18:20:11.4753490Z     generate_all_pyi(outpath, options=options)
2019-08-08T18:20:11.4755460Z   File "/usr/local/miniconda/conda-bld/pyside2_1565287062358/work/sources/pyside2/PySide2/QtCore/../support/generate_pyi.py", line 269, in generate_all_pyi
2019-08-08T18:20:11.4756980Z     generate_pyi(import_name, outpath, options)
2019-08-08T18:20:11.4758630Z   File "/usr/local/miniconda/conda-bld/pyside2_1565287062358/work/sources/pyside2/PySide2/QtCore/../support/generate_pyi.py", line 190, in generate_pyi
2019-08-08T18:20:11.4760220Z     top = __import__(import_name)
2019-08-08T18:20:11.4761710Z ImportError: dlopen(/usr/local/miniconda/conda-bld/pyside2_1565287062358/work/sources/pyside2/build/PySide2/QtCore.cpython-36m-darwin.so, 2): Symbol not found: __cg_jpeg_resync_to_restart
2019-08-08T18:20:11.4762150Z   Referenced from: /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
2019-08-08T18:20:11.4763210Z   Expected in: /usr/local/miniconda/conda-bld/pyside2_1565287062358/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/lib/libJPEG.dylib
2019-08-08T18:20:11.4763840Z  in /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
2019-08-08T18:20:11.4875430Z make[2]: *** [PySide2/QtCore/CMakeFiles/QtCore_pyi] Error 1
2019-08-08T18:20:11.4877190Z make[1]: *** [PySide2/QtCore/CMakeFiles/QtCore_pyi.dir/all] Error 2
2019-08-08T18:20:11.4877640Z make[1]: *** Waiting for unfinished jobs....
```