### PR TITLE
Drop zip source archive

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: http://download.qt.io/official_releases/qt/5.12/{{ version }}/single/qt-everywhere-src-{{ version }}.tar.xz  # [not win]
-    md5: 6a37466c8c40e87d4a19c3f286ec2542  # [not win]
-  - url: http://download.qt.io/official_releases/qt/5.12/{{ version }}/single/qt-everywhere-src-{{ version }}.zip  # [win]
-    md5: 4649d4e51ca836fbde08565582353140  # [win]
+  - url: http://download.qt.io/official_releases/qt/5.12/{{ version }}/single/qt-everywhere-src-{{ version }}.tar.xz
+    md5: 6a37466c8c40e87d4a19c3f286ec2542
     patches:
       # qtbase
       - patches/0010-osx-xctest-check.patch


### PR DESCRIPTION
I wonder why we use the zip archive, tar.xz works for win32 too for pyside2, even with patching.
If it succeeds it would allow for the bot to update cleanly the checksum.

