### PR TITLE
Detect jpeg, use tiff

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,8 @@ source:
       # qtscript
       - patches/0001-qtscript-mark-cti_vm_throw-as-REFERENCED_FROM_ASM.patch
 
+      - patches/9999-no-libjpeg-turbo.patch
+
   - url: http://download.qt.io/community_releases/5.9/5.9.0-final/qtwebkit-opensource-src-5.9.0.tar.xz            # [qtwebkit == 'true']
     sha256: 8dad193b740055a998312e04a040f2e32a923c0823b2d239b24eab08276a4e04                                      # [qtwebkit == 'true']
     folder: qtwebkit                                                                                              # [qtwebkit == 'true']
@@ -65,7 +67,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and vc != 14]
   detect_binary_files_with_prefix: true
   # QtWebEngine fails on Linux unless we merge
@@ -160,6 +162,7 @@ requirements:
     - icu
     - jpeg
     - libpng
+    - libtiff
     - nspr                               # [unix]
     - nss                                # [unix]
     - sqlite

--- a/recipe/patches/9999-no-libjpeg-turbo.patch
+++ b/recipe/patches/9999-no-libjpeg-turbo.patch
@@ -1,0 +1,15 @@
+diff --git a/qtwebengine/src/core/configure.json b/qtwebengine/src/core/configure.json
+index b9c920444..773eedc61 100644
+--- a/qtwebengine/src/core/configure.json
++++ b/qtwebengine/src/core/configure.json
+@@ -192,8 +192,8 @@
+                 ],
+                 "main": [
+                     "JDIMENSION dummy;",
+-                    "jpeg_crop_scanline(nullptr, &dummy, &dummy);",
+-                    "jpeg_skip_scanlines(nullptr, dummy);"
++                    "jpeg_create_decompress(nullptr);",
++                    "jpeg_finish_decompress(nullptr);"
+                 ]
+             },
+             "sources": [


### PR DESCRIPTION
Rationale: imageformats plugins can be linked to external libjpeg, libtiff
For jpeg, seems that qt favors libjpeg-turbo