### PR TITLE
Bump Qt version to 5.14.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
@@ -42,7 +42,7 @@ jobs:
       source activate base
       echo "Configuring conda."
 
-      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
@@ -53,24 +53,24 @@ jobs:
 
   - script: |
       source activate base
-      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
       source activate base
-      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
       source activate base
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,8 +10,8 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_cxx_compilervs2015vc14:
-        CONFIG: win_cxx_compilervs2015vc14
+      win_:
+        CONFIG: win_
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:
@@ -58,13 +58,13 @@ jobs:
       inputs:
         packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
         installOptions: "-c conda-forge"
-        updateConda: false
+        updateConda: true
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
 
     # Configure the VM
-    - script: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
+    - script: setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
 
     # Configure the VM.
     - script: |
@@ -80,7 +80,7 @@ jobs:
 
     # Special cased version setting some more things!
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
       env:
         VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
@@ -88,7 +88,7 @@ jobs:
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
@@ -96,8 +96,8 @@ jobs:
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
-        upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -12,7 +12,7 @@ jobs:
     matrix:
       win_:
         CONFIG: win_
-        CONDA_BLD_PATH: D:\\bld\\
+        CONDA_BLD_PATH: C:\\bld\\
         UPLOAD_PACKAGES: True
   steps:
     # TODO: Fast finish on azure pipelines?

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -12,7 +12,7 @@ jobs:
     matrix:
       win_cxx_compilervs2015vc14:
         CONFIG: win_cxx_compilervs2015vc14
-        CONDA_BLD_PATH: C:\\bld\\
+        CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:
     # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -39,7 +39,7 @@ nspr:
 nss:
 - '3.39'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   dbus:
     max_pin: x

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -27,7 +27,7 @@ nspr:
 nss:
 - '3.39'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   icu:
     max_pin: x

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -11,7 +11,7 @@ jpeg:
 libpng:
 - '1.6'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   icu:
     max_pin: x
@@ -31,8 +31,5 @@ sqlite:
 - '3'
 vc:
 - '14'
-zip_keys:
-- - vc
-  - cxx_compiler
 zlib:
 - '1.2'

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_cxx_compilervs2015vc14</td>
+              <td>win</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-feedstock?branchName=master&jobName=win&configuration=win_cxx_compilervs2015vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-feedstock?branchName=master&jobName=win&configuration=win_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,7 +117,6 @@ requirements:
     - pkg-config                         # [linux]
     - make                               # [unix]
     # Probably only needed for WebEngine
-    - python 2.7*
     - ninja
     - ruby >=2.5                         # [linux]
     - bison                              # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: http://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/single/qt-everywhere-src-{{ version }}.tar.xz
-    md5: d8c9ed842d39f1a5f31a7ab31e4e886c
+    md5: 781c3179410aff7ef84607214e1e91b4
     patches:
 
       # qtbase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 #   error: unknown type name 'SecKeyAlgorithm'
 # .. these 10.11 support patches should be removed anyway as they could break some things.
 # .. such as pop-up Window mouse-events.
-{% set version = "5.12.5" %}
+{% set version = "5.14.1" %}
 
 package:
   name: qt
@@ -65,7 +65,7 @@ source:
     folder: opengl32sw                                                                                            # [win64]
 
 build:
-  number: 3
+  number: 0
   skip: True  # [win and vc != 14]
   detect_binary_files_with_prefix: true
   # QtWebEngine fails on Linux unless we merge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
       - patches/0001-shobjidl-Fix-compile-guard-around-SHARDAPPIDINFOLINK.patch
 
       # qtwebengine
-      - patches/0001-qtwebengine-allow-any-xcblah-in-PATH.patch
+      # - patches/0001-qtwebengine-allow-any-xcblah-in-PATH.patch
       - patches/0002-qtwebengine-find_sdk-respect-CONDA_BUILD_SYSROOT.patch
       - patches/0004-qtwebengine-use-CONDA_PREFIX_include-for-system_libjpeg.patch
       - patches/0005-qtwebengine-jpeg-codec-cannot-convert-bool-to-boolean.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,16 +31,16 @@ source:
 
       # qtwebengine
       # - patches/0001-qtwebengine-allow-any-xcblah-in-PATH.patch
-      - patches/0002-qtwebengine-find_sdk-respect-CONDA_BUILD_SYSROOT.patch
-      - patches/0004-qtwebengine-use-CONDA_PREFIX_include-for-system_libjpeg.patch
-      - patches/0005-qtwebengine-jpeg-codec-cannot-convert-bool-to-boolean.patch
+      # - patches/0002-qtwebengine-find_sdk-respect-CONDA_BUILD_SYSROOT.patch
+      # - patches/0004-qtwebengine-use-CONDA_PREFIX_include-for-system_libjpeg.patch
+      # - patches/0005-qtwebengine-jpeg-codec-cannot-convert-bool-to-boolean.patch
       - patches/0006-qtwebengine-run-gn-verbosely.patch
       # - patches/0007-qtwebengine-macOS-10.11-support-Define-NSEventTypeScrollWheel-as.patch
-      - patches/0008-qtwebengine-link-gn-to-librt.patch
-      - patches/0009-qtwebengine-Add-conda_prefix-to-features-gni-declare_args.patch
-      - patches/0010-qtwebengine-Use-conda_prefix-for-system-zlib.patch
-      - patches/0011-qtwebengine-Use-conda_prefix-for-ui-gl.patch
-      - patches/0012-qtwebengine-Ignore-glibc-2-17-min-version-check.patch
+      # - patches/0008-qtwebengine-link-gn-to-librt.patch
+      # - patches/0009-qtwebengine-Add-conda_prefix-to-features-gni-declare_args.patch
+      # - patches/0010-qtwebengine-Use-conda_prefix-for-system-zlib.patch
+      # - patches/0011-qtwebengine-Use-conda_prefix-for-ui-gl.patch
+      # - patches/0012-qtwebengine-Ignore-glibc-2-17-min-version-check.patch
       - patches/0013-qtwebengine-missing_EVIOCGPROP.diff
       - patches/0014-qtwebengine-HAVE_SENDMMSG.diff
 


### PR DESCRIPTION
Rebased version of #149

- [ ] Build QtWebEngine
  - Fix installation of Python 2
  - or upgrade QtWebEngine build engine for Python 3 (Python 2 is EOL)

- [ ] Get more space for windows builds

```
..\..\include\QtMultimedia\QtMultimediaDepends(7): fatal error C1085: Cannot write precompiled header file: '.pch\release\Qt5Multimedia_conda_pch.pch': There is not enough space on the disk.
```

- [ ] Patch macOS specific code

```
$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++ -c -include.pch/Qt5Gui_x86_64.pch/c++_x86_64 -pipe -stdlib=libc++ -Oz -fomit-frame-pointer -fdata-sections -fvisibility=hidden -std=c++1y -fapplication-extension  -arch x86_64 -isysroot /Applications/Xcode_11.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.13 -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -Wall -Wextra -Winconsistent-missing-override -Wobjc-interface-ivars -Wobjc-method-access -Wobjc-multiple-method-names -Werror=unguarded-availability -Werror=unguarded-availability-new -Werror=unsupported-availability-guard -fPIC -DQT_NO_LINKED_LIST -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_USING_NAMESPACE -DQT_NO_FOREACH -DENABLE_PIXMAN_DRAWHELPERS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_BUILD_GUI_LIB -DQT_BUILDING_QT -DQT_NO_CAST_TO_ASCII -DQT_ASCII_CAST_WARNINGS -DQT_MOC_COMPAT -DQT_USE_QSTRINGBUILDER -DQT_DEPRECATED_WARNINGS -DQT_DISABLE_DEPRECATED_BEFORE=0x050000 -DQT_DEPRECATED_WARNINGS_SINCE=0x060000 -DQT_NO_EXCEPTIONS -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I../3rdparty/md4c -I../3rdparty/VulkanMemoryAllocator -I../../include -I../../include/QtGui -I../../include/QtGui/5.14.1 -I../../include/QtGui/5.14.1/QtGui -I.tracegen -I/System/Library/Frameworks/OpenGL.framework/Headers -I/System/Library/Frameworks/AGL.framework/Headers/ -I../../include/QtCore/5.14.1 -I../../include/QtCore/5.14.1/QtCore -I../../include/QtCore -I.moc -I$PREFIX/include -I../../mkspecs/macx-clang -o .obj/qshaderdescription.o rhi/qshaderdescription.cpp
$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++ -c -include.pch/Qt5Gui_x86_64.pch/c++_x86_64 -pipe -stdlib=libc++ -Oz -fomit-frame-pointer -fdata-sections -fvisibility=hidden -std=c++1y -fapplication-extension  -arch x86_64 -isysroot /Applications/Xcode_11.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.13 -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -Wall -Wextra -Winconsistent-missing-override -Wobjc-interface-ivars -Wobjc-method-access -Wobjc-multiple-method-names -Werror=unguarded-availability -Werror=unguarded-availability-new -Werror=unsupported-availability-guard -fPIC -DQT_NO_LINKED_LIST -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_USING_NAMESPACE -DQT_NO_FOREACH -DENABLE_PIXMAN_DRAWHELPERS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_BUILD_GUI_LIB -DQT_BUILDING_QT -DQT_NO_CAST_TO_ASCII -DQT_ASCII_CAST_WARNINGS -DQT_MOC_COMPAT -DQT_USE_QSTRINGBUILDER -DQT_DEPRECATED_WARNINGS -DQT_DISABLE_DEPRECATED_BEFORE=0x050000 -DQT_DEPRECATED_WARNINGS_SINCE=0x060000 -DQT_NO_EXCEPTIONS -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I../3rdparty/md4c -I../3rdparty/VulkanMemoryAllocator -I../../include -I../../include/QtGui -I../../include/QtGui/5.14.1 -I../../include/QtGui/5.14.1/QtGui -I.tracegen -I/System/Library/Frameworks/OpenGL.framework/Headers -I/System/Library/Frameworks/AGL.framework/Headers/ -I../../include/QtCore/5.14.1 -I../../include/QtCore/5.14.1/QtCore -I../../include/QtCore -I.moc -I$PREFIX/include -I../../mkspecs/macx-clang -o .obj/qshader.o rhi/qshader.cpp
$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++ -c -include.pch/Qt5Gui_x86_64.pch/c++_x86_64 -pipe -stdlib=libc++ -Oz -fomit-frame-pointer -fdata-sections -fvisibility=hidden -std=c++1y -fapplication-extension  -arch x86_64 -isysroot /Applications/Xcode_11.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.13 -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -Wall -Wextra -Winconsistent-missing-override -Wobjc-interface-ivars -Wobjc-method-access -Wobjc-multiple-method-names -Werror=unguarded-availability -Werror=unguarded-availability-new -Werror=unsupported-availability-guard -fPIC -DQT_NO_LINKED_LIST -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_USING_NAMESPACE -DQT_NO_FOREACH -DENABLE_PIXMAN_DRAWHELPERS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_BUILD_GUI_LIB -DQT_BUILDING_QT -DQT_NO_CAST_TO_ASCII -DQT_ASCII_CAST_WARNINGS -DQT_MOC_COMPAT -DQT_USE_QSTRINGBUILDER -DQT_DEPRECATED_WARNINGS -DQT_DISABLE_DEPRECATED_BEFORE=0x050000 -DQT_DEPRECATED_WARNINGS_SINCE=0x060000 -DQT_NO_EXCEPTIONS -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I../3rdparty/md4c -I../3rdparty/VulkanMemoryAllocator -I../../include -I../../include/QtGui -I../../include/QtGui/5.14.1 -I../../include/QtGui/5.14.1/QtGui -I.tracegen -I/System/Library/Frameworks/OpenGL.framework/Headers -I/System/Library/Frameworks/AGL.framework/Headers/ -I../../include/QtCore/5.14.1 -I../../include/QtCore/5.14.1/QtCore -I../../include/QtCore -I.moc -I$PREFIX/include -I../../mkspecs/macx-clang -o .obj/qrhigles2.o rhi/qrhigles2.cpp
$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++ -c -include.pch/Qt5Gui_x86_64.pch/objective-c++_x86_64 -pipe -stdlib=libc++ -Oz -fomit-frame-pointer -fdata-sections -fvisibility=hidden -std=c++1y -fapplication-extension  -arch x86_64 -isysroot /Applications/Xcode_11.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.13 -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -Wall -Wextra -Winconsistent-missing-override -Wobjc-interface-ivars -Wobjc-method-access -Wobjc-multiple-method-names -Werror=unguarded-availability -Werror=unguarded-availability-new -Werror=unsupported-availability-guard -fPIC -DQT_NO_LINKED_LIST -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_USING_NAMESPACE -DQT_NO_FOREACH -DENABLE_PIXMAN_DRAWHELPERS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_BUILD_GUI_LIB -DQT_BUILDING_QT -DQT_NO_CAST_TO_ASCII -DQT_ASCII_CAST_WARNINGS -DQT_MOC_COMPAT -DQT_USE_QSTRINGBUILDER -DQT_DEPRECATED_WARNINGS -DQT_DISABLE_DEPRECATED_BEFORE=0x050000 -DQT_DEPRECATED_WARNINGS_SINCE=0x060000 -DQT_NO_EXCEPTIONS -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I../3rdparty/md4c -I../3rdparty/VulkanMemoryAllocator -I../../include -I../../include/QtGui -I../../include/QtGui/5.14.1 -I../../include/QtGui/5.14.1/QtGui -I.tracegen -I/System/Library/Frameworks/OpenGL.framework/Headers -I/System/Library/Frameworks/AGL.framework/Headers/ -I../../include/QtCore/5.14.1 -I../../include/QtCore/5.14.1/QtCore -I../../include/QtCore -I.moc -I$PREFIX/include -I../../mkspecs/macx-clang -o .obj/qrhimetal.o rhi/qrhimetal.mm
rhi/qrhimetal.mm:219:44: error: unknown type name 'MTLCaptureManager'
    API_AVAILABLE(macos(10.13), ios(11.0)) MTLCaptureManager *captureMgr;
                                           ^
                         ^~~~~~~~
rhi/qrhimetal.mm:2941:20: error: use of undeclared identifier 'MTLVertexFormatUCharNormalized'
            return MTLVertexFormatUCharNormalized;
                   ^
rhi/qrhimetal.mm:3643:22: error: property 'displaySyncEnabled' not found on object of type 'CAMetalLayer *'
            d->layer.displaySyncEnabled = NO;
                     ^
4 warnings and 6 errors generated.
```
